### PR TITLE
Parse LinkedResource to BigQuery Table

### DIFF
--- a/src/main/java/com/google/cloud/solutions/datalineage/service/BigQueryPolicyTagService.java
+++ b/src/main/java/com/google/cloud/solutions/datalineage/service/BigQueryPolicyTagService.java
@@ -111,7 +111,7 @@ public final class BigQueryPolicyTagService implements Serializable {
       return
           tableEntities.stream()
               .map(DataEntity::getLinkedResource)
-              .map(BigQueryTableCreator::fromBigQueryResource)
+              .map(BigQueryTableCreator::usingBestEffort)
               .map(bqTable -> readPolicyMap(bqTable, monitoredPolicyTags))
               .flatMap(t -> t.cellSet().stream())
               .collect(


### PR DESCRIPTION
Supporting wider use-cases for Data Catalog requires parsing BigQuery Linked Resource format.