### PR TITLE
Check null in LOAD_SOURCE_TABLES read

### DIFF
--- a/src/main/java/com/google/cloud/solutions/datalineage/extractor/LoadJobExtractor.java
+++ b/src/main/java/com/google/cloud/solutions/datalineage/extractor/LoadJobExtractor.java
@@ -58,7 +58,11 @@ public final class LoadJobExtractor extends LineageExtractor {
   }
 
   private ImmutableSet<DataEntity> extractSources() {
-    return metadata().<List<String>>read(LOAD_SOURCE_TABLES).stream()
+    List<String> tables = metadata().read(LOAD_SOURCE_TABLES);
+    if(tables == null) {
+      return ImmutableSet.of();
+    }
+    return tables.stream()
         .map(CloudStorageFile::create).map(
             DataEntityConvertible::dataEntity).collect(toImmutableSet());
 


### PR DESCRIPTION
I got NullPointerException in this line. 

```
java.lang.NullPointerException
com.google.cloud.solutions.datalineage.extractor.LoadJobExtractor.extractSources(LoadJobExtractor.java:61)
com.google.cloud.solutions.datalineage.extractor.LoadJobExtractor.extract(LoadJobExtractor.java:55)
com.google.cloud.solutions.datalineage.extractor.InsertJobTableLineageExtractor.extract(InsertJobTableLineageExtractor.java:58)
com.google.cloud.solutions.datalineage.transform.LineageExtractionTransform$IdentifyAndExtract.extract(LineageExtractionTransform.java:84)
```