### PR TITLE
Add partition decorator support

### DIFF
--- a/src/main/java/com/google/cloud/solutions/datalineage/extractor/BigQueryTableCreator.java
+++ b/src/main/java/com/google/cloud/solutions/datalineage/extractor/BigQueryTableCreator.java
@@ -99,7 +99,7 @@ public abstract class BigQueryTableCreator {
 
   private static final String BQ_RESOURCE_FORMAT =
       String.format(
-          "^projects/(?<%s>%s)/datasets/(?<%s>%s)/tables/(?<%s>%s)$",
+          "^projects/(?<%s>%s)/datasets/(?<%s>%s)/tables/(?<%s>%s)(\\$[0-9]+)?$",
           PROJECT_ID_TAG, PROJECT_PATTERN, DATASET_ID_TAG, DATASET_PATTERN, TABLE_ID_TAG,
           TABLE_PATTERN);
 

--- a/src/test/java/com/google/cloud/solutions/datalineage/extractor/BigQueryTableCreatorTest.java
+++ b/src/test/java/com/google/cloud/solutions/datalineage/extractor/BigQueryTableCreatorTest.java
@@ -261,7 +261,7 @@ public final class BigQueryTableCreatorTest {
                 /*table=*/ "Lineage_table"));
   }
 
-  // BigQuery Linked Resource format
+  // BigQuery Resource format
   @Test
   public void fromBqResource_projectIfWithNumber_valid() {
     assertThat(fromBigQueryResource(
@@ -390,6 +390,18 @@ public final class BigQueryTableCreatorTest {
 
     assertThat(illegalArgumentException).hasMessageThat().startsWith(
         "input (projects/test-project/datasets/audit_dataset/tables/lineage-table) not in correct format");
+  }
+
+  @Test
+  public void fromBqResource_tableWithPartitionDecorator_valid() {
+    assertThat(
+        fromBigQueryResource(
+            "projects/example.co.in:test-project/datasets/audit_dataset/tables/lineage_table$20210606"))
+        .isEqualTo(
+            BigQueryTableEntity.create(
+                /*projectId=*/ "example.co.in:test-project",
+                /*dataset=*/ "audit_dataset",
+                /*table=*/ "lineage_table"));
   }
 
   // BigQuery Linked Resource format


### PR DESCRIPTION
Enable the lineage extraction job to parse statements that contain a [partition decorator](https://cloud.google.com/bigquery/docs/creating-partitioned-tables#write-to-partition). Partition decorators are used to write data to a specific partition, and this approach is used in some ETL systems that manage late arriving data or recovery pipelines that update specific partition data. Here's the error message when the job encounters a partition decorator: 
```
Error message from worker: java.lang.IllegalArgumentException: input(projects/my-project/datasets/lineage_testing/tables/child$20210605) not in correct format(^projects/(?<projectId>[a-zA-Z0-9\.\-\:]+)/datasets/(?<dataset>[a-zA-Z_][a-zA-Z0-9\_]+)/tables/(?<table>[a-zA-Z][a-zA-Z0-9\_]+)$)
  com.google.cloud.solutions.datalineage.extractor.BigQueryTableCreator.extractInformation(BigQueryTableCreator.java:122)
  com.google.cloud.solutions.datalineage.extractor.BigQueryTableCreator.fromBigQueryResource(BigQueryTableCreator.java:72)
  com.google.cloud.solutions.datalineage.transform.AuditLogValidator$MessageValidator.validDestinationTable(AuditLogValidator.java:65)
  com.google.cloud.solutions.datalineage.transform.AuditLogValidator$MessageValidator.isProcessableEvent(AuditLogValidator.java:56)
  com.google.cloud.solutions.datalineage.transform.AuditLogValidator.apply(AuditLogValidator.java:38)
  com.google.cloud.solutions.datalineage.transform.AuditLogValidator.apply(AuditLogValidator.java:31)
  org.apache.beam.sdk.transforms.Filter$1.processElement(Filter.java:210)
```
To reproduce (console):
```sql
CREATE TABLE
  lineage_testing.parent (test_id INT64, test_date DATE)
PARTITION BY
  test_date

INSERT INTO `lineage_testing.parent` VALUES (1, '2021-06-06')

CREATE TABLE
  lineage_testing.child (test_id INT64, test_date DATE)
PARTITION BY
  test_date
```
Then run:
```sh
bq query \
  --use_legacy_sql=false  \
  --destination_table='my-project:lineage_testing.child$20210605' \
  --append_table=true \
  'SELECT * FROM `my-project.lineage_testing.parent`'
```

Legacy SQL does not support partition updates, so this change is only applied to the BQ standard sql resource regex. I didn't see any value in further processing or tracking the partition, so the partition identifier is silently dropped - lineage details relating to the partition column are still tracked as usual.
