### PR TITLE
checkpointing dml merge statement support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.version>3.6.1.1688</sonar.version>
     <sonar.version>3.6.1.1688</sonar.version>
-    <zetasql.version>2021.02.1</zetasql.version>
+    <zetasql.version>2021.03.2</zetasql.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <truth.version>1.1.2</truth.version>
   </properties>

--- a/src/main/java/com/google/cloud/solutions/datalineage/BigQuerySqlParser.java
+++ b/src/main/java/com/google/cloud/solutions/datalineage/BigQuerySqlParser.java
@@ -17,7 +17,6 @@
 package com.google.cloud.solutions.datalineage;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.zetasql.Analyzer.extractTableNamesFromStatement;
 
 import com.google.cloud.solutions.datalineage.extractor.ColumnLineageExtractor;
 import com.google.cloud.solutions.datalineage.extractor.ColumnLineageExtractorFactory;
@@ -110,7 +109,7 @@ public class BigQuerySqlParser {
   }
 
   private static ImmutableSet<String> extractReferencedTables(String sql) {
-    return extractTableNamesFromStatement(sql).stream()
+    return Analyzer.extractTableNamesFromStatement(sql, enableAllFeatures()).stream()
         .flatMap(List::stream)
         .collect(toImmutableSet());
   }
@@ -119,9 +118,11 @@ public class BigQuerySqlParser {
     return Analyzer.analyzeStatement(sql, enableAllFeatures(), buildCatalogWithQueryTables(sql));
   }
 
-  private AnalyzerOptions enableAllFeatures() {
+  private static AnalyzerOptions enableAllFeatures() {
+    LanguageOptions languageOptions = new LanguageOptions().enableMaximumLanguageFeatures();
+    languageOptions.setSupportsAllStatementKinds();
     AnalyzerOptions analyzerOptions = new AnalyzerOptions();
-    analyzerOptions.setLanguageOptions(new LanguageOptions().enableMaximumLanguageFeatures());
+    analyzerOptions.setLanguageOptions(languageOptions);
     analyzerOptions.setPruneUnusedColumns(true);
 
     return analyzerOptions;

--- a/src/main/java/com/google/cloud/solutions/datalineage/extractor/OutputColumnExtractor.java
+++ b/src/main/java/com/google/cloud/solutions/datalineage/extractor/OutputColumnExtractor.java
@@ -57,8 +57,49 @@ public final class OutputColumnExtractor {
               nonTableColumnTypes.add(resolvedColumn.getTableName());
             }
 
-            super.visit(outputColumn);
           }
+
+          @Override
+          public void visit(ResolvedNodes.ResolvedMergeStmt mergeStmt) {
+            mergeStmt.getFromScan().getColumnList().forEach(resolvedColumn -> {
+              outputColumnBuilder.put(resolvedColumn.getName(),
+                  convertToColumnEntity(resolvedColumn));
+              if (resolvedColumn.getTableName().startsWith("$")) {
+                nonTableColumnTypes.add(resolvedColumn.getTableName());
+              }
+            });
+            super.visit(mergeStmt);
+          }
+
+          /*
+          //TODO skuehn enable after testing
+
+          @Override
+          public void visit(ResolvedNodes.ResolvedInsertStmt insertStmt) {
+            insertStmt.getQueryOutputColumnList().forEach(resolvedColumn -> {
+              outputColumnBuilder.put(resolvedColumn.getName(),
+                  convertToColumnEntity(resolvedColumn));
+              if (resolvedColumn.getTableName().startsWith("$")) {
+                nonTableColumnTypes.add(resolvedColumn.getTableName());
+              }
+            });
+            super.visit(insertStmt);
+          }
+
+          @Override
+          public void visit(ResolvedNodes.ResolvedUpdateStmt updateStmt) {
+            //TODO skuehn verify these resolvedoutputcolumns aren't passed through output column visitor again
+            updateStmt.getReturning().getOutputColumnList().forEach(resolvedOutputColumn -> {
+              outputColumnBuilder.put(resolvedOutputColumn.getName(),
+                  convertToColumnEntity(resolvedOutputColumn.getColumn()));
+              if (resolvedOutputColumn.getColumn().getTableName().startsWith("$")) {
+                nonTableColumnTypes.add(resolvedOutputColumn.getColumn().getTableName());
+              }
+            });
+            super.visit(updateStmt);
+          }
+
+           */
         });
 
     return QueryColumns.builder()

--- a/src/test/resources/schemas/error_stats_agg_table_schema.json
+++ b/src/test/resources/schemas/error_stats_agg_table_schema.json
@@ -1,0 +1,35 @@
+{
+  "kind": "bigquery#table",
+  "etag": "67ikpVxNRNgZ/qN3lzqfag==",
+  "id": "myproject:reporting.error_stats_agg",
+  "selfLink": "https://content-bigquery.googleapis.com/bigquery/v2/projects/myproject/datasets/reporting/tables/error_stats_agg",
+  "tableReference": {
+    "projectId": "myproject",
+    "datasetId": "reporting",
+    "tableId": "error_stats_agg"
+  },
+  "schema": {
+    "fields": [
+      {
+        "name": "partner_id",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "num_hits",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      }
+    ]
+  },
+  "timePartitioning": {
+    "type": "DAY"
+  },
+  "numBytes": "338991985246",
+  "numLongTermBytes": "217579338469",
+  "numRows": "4647568034",
+  "creationTime": "1546166683743",
+  "lastModifiedTime": "1589587976402",
+  "type": "TABLE",
+  "location": "US"
+}

--- a/src/test/resources/schemas/public_dataset_mbb_team_colors_schema_merge.json
+++ b/src/test/resources/schemas/public_dataset_mbb_team_colors_schema_merge.json
@@ -1,0 +1,43 @@
+{
+  "kind": "bigquery#table",
+  "etag": "6ts/A4Iuhza8C7naNAHI0R==",
+  "id": "bigquery-public-data:ncaa_basketball.team_colors_merge",
+  "selfLink": "https://content-bigquery.googleapis.com/bigquery/v2/projects/bigquery-public-data/datasets/ncaa_basketball/tables/team_colors_merge",
+  "tableReference": {
+    "projectId": "bigquery-public-data",
+    "datasetId": "ncaa_basketball",
+    "tableId": "team_colors_merge"
+  },
+  "description": "Hex color codes for the 351 current men's D1 basketball teams.",
+  "schema": {
+    "fields": [
+      {
+        "name": "market",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "id",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "code_ncaa",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "color",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      }
+    ]
+  },
+  "numBytes": "23909",
+  "numLongTermBytes": "23909",
+  "numRows": "351",
+  "creationTime": "1520301383660",
+  "lastModifiedTime": "1527778180427",
+  "type": "TABLE",
+  "location": "US"
+}

--- a/src/test/resources/sql/error_stats_merge.sql
+++ b/src/test/resources/sql/error_stats_merge.sql
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+#standardSQL
+MERGE `myproject.reporting.error_stats_agg` target
+USING `myproject.reporting.error_stats` source
+ON target.partner_id = source.partner_id
+WHEN MATCHED THEN
+  UPDATE SET num_hits = target.num_hits + source.num_hits
+WHEN NOT MATCHED THEN
+  INSERT (partner_id, num_hits) VALUES (partner_id, num_hits)

--- a/src/test/resources/sql/nbaa_public_dataset_merge.sql
+++ b/src/test/resources/sql/nbaa_public_dataset_merge.sql
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+#standardSQL
+MERGE `bigquery-public-data.ncaa_basketball.team_colors_merge` target
+USING `bigquery-public-data.ncaa_basketball.team_colors` source
+ON FALSE
+WHEN NOT MATCHED THEN
+  INSERT ROW


### PR DESCRIPTION
This branch is starting to get large, so posting a draft for early 👀 and to share the approach. Note the MERGE dml was enabled in the latest zetasql release, making this support possible. Work remaining:
* the TODO's in BigQuerySqlParserTest
* replace the MERGE ncaa 'copy' test with a more canonical test case, such as the agg/rollup test
* If insert/update are non-trivial I'll back them out and work a separate update. The goal of this patch was MERGE support but the insert/update seemed like similar patterns so I've included them in scope. Lot's of testing is necessary here, and i've been basing tests on the scenarios described here: https://cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax#merge_statement
* end-to-end testing