### PR TITLE
improved validation when no destination table received

### DIFF
--- a/src/main/java/com/google/cloud/solutions/datalineage/transform/AuditLogValidator.java
+++ b/src/main/java/com/google/cloud/solutions/datalineage/transform/AuditLogValidator.java
@@ -61,9 +61,14 @@ public abstract class AuditLogValidator implements SerializableFunction<String, 
     }
 
     private boolean validDestinationTable() {
+      
+      List<String> destinationTableList = parser.forSubNode(METADATA_ROOT).<List<String>>read(QUERY_DESTINATION_TABLE);
+      if(destinationTableList.size() <= 0) {
+        return false;
+      }
+      
       BigQueryTableEntity destinationTable =
-          fromBigQueryResource(
-              parser.forSubNode(METADATA_ROOT).<List<String>>read(QUERY_DESTINATION_TABLE).get(0));
+          fromBigQueryResource(destinationTableList.get(0));
 
       return !(destinationTable.isTempTable() || getOutputLineageTable().equals(destinationTable));
     }


### PR DESCRIPTION
we have been facing errors in specific query scenarios where we did not had any destination table.
due to this scenario we were facing below error.

Error message from worker: java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0 java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)

This is resolution above specified that error.