### PR TITLE
add insert support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.version>3.6.1.1688</sonar.version>
     <sonar.version>3.6.1.1688</sonar.version>
-    <zetasql.version>2021.02.1</zetasql.version>
+    <zetasql.version>2021.03.2</zetasql.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <truth.version>1.1.2</truth.version>
   </properties>

--- a/src/main/java/com/google/cloud/solutions/datalineage/extractor/ColumnLineageExtractorFactory.java
+++ b/src/main/java/com/google/cloud/solutions/datalineage/extractor/ColumnLineageExtractorFactory.java
@@ -27,7 +27,6 @@ import com.google.zetasql.AnalyzerOptions;
 import com.google.zetasql.SimpleCatalog;
 import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedStatement;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -91,22 +90,10 @@ public final class ColumnLineageExtractorFactory {
   }
 
   /**
-   * Returns a set of applicable Extractors for the provided SQL query.
+   * Returns a set of applicable Extractors
    */
   public ImmutableSet<ColumnLineageExtractor> buildExtractors() {
-    return outputColumns()
-        .getProcessedColumnTypes().stream()
-        .map(this::buildExtractorFor)
-        .flatMap(Collection::stream)
-        .distinct()
-        .collect(toImmutableSet());
-  }
-
-  /**
-   * Returns a set of extractors for given columnType or empty set, if not find.
-   */
-  public ImmutableSet<ColumnLineageExtractor> buildExtractorFor(String columnType) {
-    return extractorTypeMap.get(columnType).stream()
+    return extractorTypeMap.values().stream()
         .map(clazz -> buildExtractor(clazz, resolvedStatement))
         .filter(Optional::isPresent)
         .map(Optional::get)

--- a/src/main/java/com/google/cloud/solutions/datalineage/extractor/InsertStatementExtractor.java
+++ b/src/main/java/com/google/cloud/solutions/datalineage/extractor/InsertStatementExtractor.java
@@ -1,0 +1,58 @@
+package com.google.cloud.solutions.datalineage.extractor;
+
+import static com.google.cloud.solutions.datalineage.converter.ResolvedColumnToColumnEntityConverter.convertToColumnEntity;
+
+import com.google.cloud.solutions.datalineage.model.LineageMessages.ColumnEntity;
+import com.google.cloud.solutions.datalineage.model.LineageMessages.ColumnLineage;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.zetasql.resolvedast.ResolvedColumn;
+import com.google.zetasql.resolvedast.ResolvedNodes;
+import java.util.HashMap;
+import java.util.stream.IntStream;
+
+public class InsertStatementExtractor extends ColumnLineageExtractor {
+
+  public InsertStatementExtractor(ResolvedNodes.ResolvedStatement resolvedStatement) {
+    super(resolvedStatement);
+  }
+
+  @Override
+  public String getSupportedColumnType() {
+    // TODO skuehn this PR determine how to support column types and the extractor instantiation
+    //   optimizations
+    return null;
+  }
+
+  @Override
+  public ImmutableMap<ColumnEntity, ColumnLineage> extract() {
+    HashMap<ColumnEntity, ColumnLineage> exprLineageMapBuilder = new HashMap<>();
+
+    resolvedStatement.accept(
+        new ResolvedNodes.Visitor() {
+          @Override
+          public void visit(ResolvedNodes.ResolvedInsertStmt insertStmt) {
+            if (!insertStmt.getQueryOutputColumnList().isEmpty()) {
+              // For inserts, BQ requires values to be added in the same order as the specified
+              // columns, and the number of values added must match the number of specified columns.
+              IntStream.range(0, insertStmt.getInsertColumnList().size()).forEach(columnIndex -> {
+                ColumnEntity outputColumn =
+                    convertToColumnEntity(insertStmt.getInsertColumnList().get(columnIndex));
+                ResolvedColumn sourceColumn = insertStmt.getQueryOutputColumnList()
+                    .get(columnIndex);
+
+                exprLineageMapBuilder.put(
+                    outputColumn,
+                    ColumnLineage.newBuilder()
+                        .setTarget(outputColumn)
+                        .addAllParents(ImmutableList.of(convertToColumnEntity(sourceColumn)))
+                        .build());
+              });
+            }
+            super.visit(insertStmt);
+          }
+        });
+
+    return ImmutableMap.copyOf(exprLineageMapBuilder);
+  }
+}

--- a/src/main/java/com/google/cloud/solutions/datalineage/model/QueryColumns.java
+++ b/src/main/java/com/google/cloud/solutions/datalineage/model/QueryColumns.java
@@ -16,16 +16,12 @@
 
 package com.google.cloud.solutions.datalineage.model;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.solutions.datalineage.model.LineageMessages.ColumnEntity;
-import com.google.cloud.solutions.datalineage.model.LineageMessages.DataEntity.DataEntityTypes;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
@@ -39,15 +35,6 @@ import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
 public abstract class QueryColumns {
 
   public abstract ImmutableMap<String, ColumnEntity> getColumnMap();
-
-  public final ImmutableSet<String> getProcessedColumnTypes() {
-    return getColumnMap().values().stream()
-        .filter(columnEntity -> columnEntity.getTable().getKind()
-            .equals(DataEntityTypes.QUERY_LEVEL_TABLE))
-        .map(columnEntity -> columnEntity.getTable().getSqlResource())
-        .filter(tableName -> tableName.startsWith("$"))
-        .collect(toImmutableSet());
-  }
 
   @SchemaCreate
   public static QueryColumns create(ImmutableMap<String, ColumnEntity> columnMap) {

--- a/src/test/resources/sql/tableA_infer_columns_insert.sql
+++ b/src/test/resources/sql/tableA_infer_columns_insert.sql
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+#standardSQL
+INSERT
+  `project1.datasetA.TableA`
+SELECT
+  colB,
+  colC
+FROM
+  `project2.datasetB.TableB`

--- a/src/test/resources/sql/tableA_specify_columns_insert.sql
+++ b/src/test/resources/sql/tableA_specify_columns_insert.sql
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+#standardSQL
+INSERT
+  `project1.datasetA.TableA` (colA,
+    colC)
+SELECT
+  colB,
+  colC
+FROM
+  `project2.datasetB.TableB`


### PR DESCRIPTION
This is another WIP draft of partial DML support. The column->extractor selection is broken due to tables resolving to their names rather than the query type $query/$aggregate/etc.... This patch removes the extractor filtering, so all extractors will always run. I'm not sure if this is inefficient, b/c the visitors of irrelevant extractors don't seem to be invoked. Any thoughts appreciated.